### PR TITLE
switch cond order, Color before Bitmap-Pattern

### DIFF
--- a/bitmap/digitama/base.rkt
+++ b/bitmap/digitama/base.rkt
@@ -3,6 +3,7 @@
 (provide (all-defined-out))
 
 (define-type Color (U Symbol Integer FlColor))
+(define-predicate color? Color)
 
 (struct paint () #:transparent #:type-name Paint)
 (struct flcolor () #:transparent #:type-name FlColor)

--- a/bitmap/digitama/source.rkt
+++ b/bitmap/digitama/source.rkt
@@ -25,8 +25,8 @@
 (define fill-paint->source : (-> Fill-Paint Bitmap-Source)
   (lambda [paint]
     (cond [(bitmap? paint) (bitmap-surface paint)]
-          [(bitmap-pattern? paint) paint]
-          [else (rgb* paint)])))
+          [(color? paint) (rgb* paint)]
+          [else paint])))
 
 (define fill-paint->source* : (-> (Option Fill-Paint) (Option Bitmap-Source))
   (lambda [paint]


### PR DESCRIPTION
This adds a predicate `color?` for the `Color` type, and uses that predicate to distinguish `Color` from `Bitmap-Pattern`, instead of using the `bitmap-pattern?` opaque-type predicate imported by `unsafe-require/typed/provide` in `unsafe/source.rkt`.

This change is related to the Typed Racket pull request https://github.com/racket/typed-racket/pull/882, which fixes an unsoundness in opaque-type predicates. This change allows this code to typecheck after the unsoundness is fixed.