### PR TITLE
Check that keys are numbers before sorting.

### DIFF
--- a/bitmap/digitama/misc.rkt
+++ b/bitmap/digitama/misc.rkt
@@ -18,5 +18,5 @@
     (define value (dynamic-require src.rkt id fallback))
     (cond [(not (hash? value)) value]
           [else (hash-ref value (exact->inexact density)
-                          (λ [] (let ([all (sort (hash-keys value) >)])
+                          (λ [] (let ([all (sort (assert (hash-keys value) (lambda ([l : (Listof Any)]) (andmap real? l))) >)])
                                   (if (pair? all) (hash-ref value (car all)) value))))])))


### PR DESCRIPTION
Typed Racket fixed the type of `sort` in https://github.com/racket/typed-racket/pull/1008
which broke this code. The code was relying on a bug to typecheck.