### PR TITLE
use type-id as the type name when it is specified

### DIFF
--- a/bitmap/color.rkt
+++ b/bitmap/color.rkt
@@ -27,9 +27,9 @@
        (syntax/loc stx
          (begin (struct clra flcolor ([com : Flonum] ... [alpha : Flonum])
                   #:transparent #:type-name FlCLRA)
-                (define (clr [com : Real] ... [alpha : Real 1.0]) : clra
+                (define (clr [com : Real] ... [alpha : Real 1.0]) : FlCLRA
                   (clra (real->flonum com) ... (real->alpha alpha)))
-                (define (clr* [src : Color] [alpha : Real 1.0]) : clra
+                (define (clr* [src : Color] [alpha : Real 1.0]) : FlCLRA
                   (cond [(clra? src) (if (= alpha 1.0) src (clra (clr-com src) ... (* (clr-alpha src) (real->alpha alpha))))]
                         [else (let ([flrgba (rgb* src alpha)])
                                 (define-values (com ...) (rgb->clr (rgba-red flrgba) (rgba-green flrgba) (rgba-blue flrgba)))

--- a/bitmap/paint.rkt
+++ b/bitmap/paint.rkt
@@ -50,7 +50,7 @@
             (cond [(stroke-line-cap-option? cap) cap] [(eq? dash 'dot) 'round] [else (stroke-linecap baseline)])
             linejoin miterlimit dasharray dashoffset)))
 
-(define desc-border : (->* () (stroke #:color (Option Color) #:width (U Real Symbol False) #:style (Option Symbol)) Stroke)
+(define desc-border : (->* () (Stroke #:color (Option Color) #:width (U Real Symbol False) #:style (Option Symbol)) Stroke)
   (lambda [[baseline (default-border)] #:color [color #false] #:width [width #false] #:style [dash #false]]
     (define no-border? : Boolean (or (eq? dash 'none) (eq? dash 'hidden)))
     (define linewidth : Nonnegative-Flonum


### PR DESCRIPTION
Typed Racket has a bug where struct-id can be used as the type name even when type-id is specified. 
But that is not the design intention. 
A new change to Typed Racket will fix the bug but break your code.

This PR should make your code forward-compatible. 
Sorry for the inconvenience.