### PR TITLE
Fix type error from `acos` returning Number

### DIFF
--- a/geofun/digitama/geometry/polygon/arrow.rkt
+++ b/geofun/digitama/geometry/polygon/arrow.rkt
@@ -66,7 +66,7 @@
       (if (and draw-shaft? (> shaft-length shaft-minlen))
           (let*-values ([(shaft-radius) (sqrt (+ (* shaft-thickness/2 shaft-thickness/2)
                                                  (* shaft-length shaft-length)))]
-                        [(shdelta) (+ (acos (/ shaft-thickness/2 shaft-radius)) pi/2)]
+                        [(shdelta) (+ (assert (acos (min 1.0 (/ shaft-thickness/2 shaft-radius))) flonum?) pi/2)]
                         [(shtail1 shtail2) (values (+ rpoint shdelta) (- rpoint shdelta))]
                         [(shx1 shy1) (values (* shaft-radius (cos shtail1)) (* shaft-radius (sin shtail1)))]
                         [(shx2 shy2) (values (* shaft-radius (cos shtail2)) (* shaft-radius (sin shtail2)))])


### PR DESCRIPTION
Typed Racket's `acos` now returns `Number` for `Real` inputs after
https://github.com/racket/typed-racket/pull/1428, so clamp the argument to `[-?, 1.0]` (it's
already non-negative by construction) and assert the result is
`flonum?`.